### PR TITLE
Change the scripts in package.json to use npx and not the deprecated way

### DIFF
--- a/WorkoutApp/package.json
+++ b/WorkoutApp/package.json
@@ -3,10 +3,10 @@
    "version": "1.0.0",
    "main": "node_modules/expo/AppEntry.js",
    "scripts": {
-      "start": "expo start",
-      "android": "expo start --android",
-      "ios": "expo start --ios",
-      "web": "expo start --web"
+      "start": "npx expo start",
+      "android": "npx expo start --android",
+      "ios": "npx expo start --ios",
+      "web": "npx expo start --web"
    },
    "dependencies": {
       "@expo-google-fonts/lato": "^0.2.3",


### PR DESCRIPTION
So we can use yarn iOS and not have it use the deprecated way to run expo, so I updated the package.json