### PR TITLE
Efrain-WA-100_Fix_SafeAreaView

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { StatusBar as ExpoStatusBar } from 'expo-status-bar'
 import { ThemeProvider } from 'styled-components/native'
 import { theme } from './src/infrastructure/theme'
@@ -7,10 +6,8 @@ import {
    Oswald_400Regular,
 } from '@expo-google-fonts/oswald'
 import { useFonts as useLato, Lato_400Regular } from '@expo-google-fonts/lato'
-import { StatusBar } from 'react-native'
 import { Navigator } from './src/infrastructure/navigation'
 import { SafeArea } from './src/components/utilities/safeArea.component'
-import { SafeAreaView } from 'react-native-safe-area-context'
 
 export default function App() {
    const [oswaldLoaded] = useOswald({ Oswald_400Regular })
@@ -18,11 +15,11 @@ export default function App() {
    if (!oswaldLoaded || !latoLoaded) return null
 
    return (
-      <>
+      <SafeArea>
          <ThemeProvider theme={theme}>
             <Navigator />
          </ThemeProvider>
          <ExpoStatusBar style="light" />
-      </>
+      </SafeArea>
    )
 }

--- a/src/components/utilities/safeArea.component.js
+++ b/src/components/utilities/safeArea.component.js
@@ -1,7 +1,6 @@
-import { SafeAreaView, StatusBar } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import styled from 'styled-components'
 
 export const SafeArea = styled(SafeAreaView)`
    flex: 1;
-   ${StatusBar.currentHeight && `margin-top: ${StatusBar.currentHeight}px;`}
 `


### PR DESCRIPTION
   1. Removed styling that wasn't flex: 1
   2. Updated safeAreaView to use the more uptodate version from react-native-safe-area-context since it should have better android support
   3. This makes styling not needed (and maybe was breaking it too)